### PR TITLE
Update hashtags, reducing duration of LeptonPhoton19

### DIFF
--- a/cds_paper_bot.py
+++ b/cds_paper_bot.py
@@ -68,7 +68,9 @@ class Conference(object):
 CONFERENCES = []
 # CONFERENCES.append(Conference("Moriond", maya.parse(f'{maya.now().year}-03-09'), maya.parse(f'{maya.now().year}-04-05')))
 CONFERENCES.append(Conference("EPSHEP2019", maya.parse("2019-07-08"), maya.parse("2019-07-17")))
-CONFERENCES.append(Conference("LeptonPhoton19", maya.parse("2019-08-03"), maya.parse("2019-10-10")))
+CONFERENCES.append(Conference("LeptonPhoton19", maya.parse("2019-08-03"), maya.parse("2019-08-10")))
+CONFERENCES.append(Conference("topq2019", maya.parse("2019-09-20"), maya.parse("2019-09-28")))
+CONFERENCES.append(Conference("HiggsCouplings", maya.parse("2019-09-29"), maya.parse("2019-10-06")))
 
 daiquiri.setup(level=logging.INFO)
 logger = daiquiri.getLogger()  # pylint: disable=invalid-name


### PR DESCRIPTION
The previous duration of LeptonPhoton19 was far too long... Added topq2019 (already over) and HiggsCouplings based on what I found on twitter.

FYI @SaMeHub 