### PR TITLE
Update feedparser to 6.0.8 to fix setuptools removal of 2to3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 daiquiri==2.1.1
-feedparser==5.2.1
+feedparser==6.0.8
 pylatexenc==2.3
 maya==0.6.1
 requests==2.23.0


### PR DESCRIPTION
- [`feedparser==5.2.1` relies on 2to3](https://github.com/kurtmckee/feedparser/blob/5.2.1/setup.py#L6) 
- however, [`2to3` support has been removed from setuptools since 58.0.0](https://setuptools.readthedocs.io/en/latest/history.html#breaking-changes)

Fixed by updating to next major release of `feedparser`.