### PR TITLE
Add LHCP hashtag without year

### DIFF
--- a/cds_paper_bot.py
+++ b/cds_paper_bot.py
@@ -102,6 +102,9 @@ CONFERENCES.append(
     Conference("LHCP2023", maya.parse("2023-05-21"), maya.parse("2023-05-31"))
 )
 CONFERENCES.append(
+    Conference("LHCP", maya.parse("2023-05-21"), maya.parse("2023-05-31"))
+)
+CONFERENCES.append(
     Conference("ICHEP2024", maya.parse("2024-07-16"), maya.parse("2024-07-26"))
 )
 CONFERENCES.append(


### PR DESCRIPTION
Apparently, there is no standard, so let's just use both.